### PR TITLE
Update for Makie v0.24.6

### DIFF
--- a/src/Escher.jl
+++ b/src/Escher.jl
@@ -439,7 +439,6 @@ function Makie.plot!(ep::EscherPlot{<:Tuple{String}})
 
                 #arrows!(
                     #ep,
-                    #ax,
                     #points,
                     #directions;
                     #arrowcolor = color,
@@ -477,7 +476,6 @@ function Makie.plot!(ep::EscherPlot{<:Tuple{String}})
     # Plot metabolites 
     scatter!(
         ep,
-        #ax,
         metabolites.positions,
         color = metabolites.colors,
         markersize = metabolites.markersizes,


### PR DESCRIPTION
Hi @stelmo.

The latest version of Makie has some attribute changes for arrows (affecting reaction arrowheads), so the recipe fails when supplying a reaction direction dictionary. It's a quick bodge, but I just updated the [attributes](https://docs.makie.org/dev/reference/plots/arrows#Arrow-Components-and-Details) to use a scaling factor for `tipwidth` and `tiplength` and increased the `lengthscale` since that seems to limit the maximum size of the arrow(head).